### PR TITLE
Wait for instance storage mount before formatting

### DIFF
--- a/prepare-local-disk.bash
+++ b/prepare-local-disk.bash
@@ -83,6 +83,12 @@ if [[ -n "${LAUNCHCTL_RESULT}" ]]; then
     launchctl unload -w /Library/LaunchDaemons/com.amazon.ec2.instance-storage-disk-mounter.plist
     echo "Amazon script that mounts the instance storage disk as /Volumes/ephemeral0 unloaded."
 
+    echo "Waiting for any in-flight instance storage mount to settle..."
+    for _ in {1..30}; do
+        mount | grep -q "/Volumes/ephemeral0" && break
+        sleep 1
+    done
+
     # Erase and format the disk if it's mounted as /Volumes/ephemeral0
     if mount | grep -q "/Volumes/ephemeral0"; then
         apfs_store=$(diskutil list "${EXTERNAL_DEVICE}" | awk '/Apple_APFS/ {print $NF; exit}')


### PR DESCRIPTION
## Summary

Wait briefly for the default instance-storage mounter to settle before formatting the local disk.

We hit this today on a macOS EC2 host: the script unloaded the default instance-storage launch daemon, checked for `/Volumes/ephemeral0` immediately, and skipped the existing cleanup path because the volume had not appeared yet. Shortly afterward the disk mounted as `/Volumes/ephemeral0`, and the later `diskutil eraseDisk` call failed because the device was still busy.

This adds a bounded wait for `/Volumes/ephemeral0` to appear before the existing cleanup logic runs.